### PR TITLE
Fix report engine top queries

### DIFF
--- a/pkg/report_templates/clickhouse_resport_templates/top_queries_html_template.go
+++ b/pkg/report_templates/clickhouse_resport_templates/top_queries_html_template.go
@@ -12,7 +12,14 @@ const TopQueriesHTMLTemplate = `
         <td></td>
     </tr>
     <tr>
-        <td>{{.Records}}</td>
+    {{range $record:=.}}
+    <td>{{$record.Pos}}</td>
+    <td>{{$record.TotalDuration}}</td>
+    <td>{{$record.TotalDurationPercentage}}</td>
+    <td>{{$record.Count}}</td>
+    <td>{{$record.ResponseTimePerCall}}</td>
+    <td>{{$record.Query}}</td>
+    {{end}}     
     </tr>
 </table>
 `

--- a/pkg/report_templates/clickhouse_resport_templates/top_queries_md_template.go
+++ b/pkg/report_templates/clickhouse_resport_templates/top_queries_md_template.go
@@ -4,7 +4,9 @@ const TopQueriesMDTemplate = `
 # Top Queries
 | Rank | Response time  | Calls | R/Call | Query |   
 |------|----------------|-------|--------|-------|
-{{.Records}}
+{{range $record:=.}}
+|{{$record.Pos}}|{{$record.TotalDuration}}|{{$record.TotalDurationPercentage}}|{{$record.Count}}|{{$record.ResponseTimePerCall}}|{{$record.Query}}|
+{{end}}
 `
 
 const TopQueryMDRecord = `| {{.Pos}} | {{.TotalDuration}} {{.TotalDurationPercentage}} |  {{.Count}} | {{.ResponseTimePerCall}} | {{.Query}} |`

--- a/pkg/report_templates/clickhouse_resport_templates/top_queries_text_template.go
+++ b/pkg/report_templates/clickhouse_resport_templates/top_queries_text_template.go
@@ -4,7 +4,9 @@ const TopQueriesTemplate = `
 # Profile
 # Rank Response time   Calls R/Call Query
 # ==== =============== ===== ====== =====
-{{.Records}}
+{{range $record:=.}}
+{{$record.Pos}}|{{$record.TotalDuration}}|{{$record.TotalDurationPercentage}}|{{$record.Count}}|{{$record.ResponseTimePerCall}}|{{$record.Query}}
+{{end}}
 `
 
 const TopQueryRecord = `# {{.Pos}} {{.TotalDuration}} {{.TotalDurationPercentage}} {{.Count}} {{.ResponseTimePerCall}} {{.Query}}`

--- a/pkg/report_templates/postgres_resport_templates/top_queries_html_template.go
+++ b/pkg/report_templates/postgres_resport_templates/top_queries_html_template.go
@@ -12,7 +12,14 @@ const TopQueriesHTMLTemplate = `
         <td></td>
     </tr>
     <tr>
-        <td>{{.Records}}</td>
+        {{range $record:=.}}
+        <td>{{$record.Pos}}</td>
+        <td>{{$record.TotalDuration}}</td>
+        <td>{{$record.TotalDurationPercentage}}</td>
+        <td>{{$record.Count}}</td>
+        <td>{{$record.ResponseTimePerCall}}</td>
+        <td>{{$record.Query}}</td>
+        {{end}}  
     </tr>
 </table>
 `

--- a/pkg/report_templates/postgres_resport_templates/top_queries_md_template.go
+++ b/pkg/report_templates/postgres_resport_templates/top_queries_md_template.go
@@ -4,7 +4,9 @@ const TopQueriesMDTemplate = `
 # Top Queries
 | Rank | Response time  | Calls | R/Call | Query |   
 |------|----------------|-------|--------|-------|
-{{.Records}}
+{{range $record:=.}}
+|{{$record.Pos}}|{{$record.TotalDuration}}|{{$record.TotalDurationPercentage}}|{{$record.Count}}|{{$record.ResponseTimePerCall}}|{{$record.Query}}|
+{{end}}
 `
 
 const TopQueryMDRecord = `| {{.Pos}} | {{.TotalDuration}} {{.TotalDurationPercentage}} |  {{.Count}} | {{.ResponseTimePerCall}} | {{.Query}} |`

--- a/pkg/report_templates/postgres_resport_templates/top_queries_text_template.go
+++ b/pkg/report_templates/postgres_resport_templates/top_queries_text_template.go
@@ -4,7 +4,9 @@ const TopQueriesTemplate = `
 # Profile
 # Rank Response time   Calls R/Call Query
 # ==== =============== ===== ====== =====
-{{.Records}}
+{{range $record:=.}}
+{{$record.Pos}}|{{$record.TotalDuration}}|{{$record.TotalDurationPercentage}}|{{$record.Count}}|{{$record.ResponseTimePerCall}}|{{$record.Query}}
+{{end}}
 `
 
 const TopQueryRecord = `# {{.Pos}} {{.TotalDuration}} {{.TotalDurationPercentage}} {{.Count}} {{.ResponseTimePerCall}} {{.Query}}`

--- a/pkg/services/report_generator.go
+++ b/pkg/services/report_generator.go
@@ -130,11 +130,11 @@ func (reportGenerator ReportGenerator) GenerateReport() {
 		topQueriesRecords = append(topQueriesRecords, stucts.InitTopQueriesTemplateInputRecord(sortedSimilarQueryInfos[i], &queryInfoTemplateInputs[i], accumulatedInfoTemplateInput.TotalDuration))
 	}
 
-	topQueriesTemplateInput := stucts.InitTopQueriesTemplateInput(topQueriesRecords, reportGenerator.ReportTemplates.TopQueryRecordTemplate)
+	// topQueriesTemplateInput := stucts.InitTopQueriesTemplateInput(topQueriesRecords, reportGenerator.ReportTemplates.TopQueryRecordTemplate)
 
 	// Generating output from templates, to a buffer
 
-	reportString, err := reportGenerator.executeTemplates(accumulatedInfoTemplateInput, topQueriesTemplateInput, queryInfoTemplateInputs)
+	reportString, err := reportGenerator.executeTemplates(accumulatedInfoTemplateInput, topQueriesRecords, queryInfoTemplateInputs)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -156,7 +156,7 @@ func (reportGenerator ReportGenerator) GenerateReport() {
 	log.Info("Report generated successfully, output." + reportGenerator.OutputFileExtension + " created.")
 }
 
-func (reportGenerator ReportGenerator) executeTemplates(accumulatedInfoTemplateInput stucts.AccumulatedInfoTemplateInput, topQueriesTemplateInput stucts.TopQueriesTemplateInput, queryInfoTemplateInputs []stucts.QueryInfoTemplateInput) (string, error) {
+func (reportGenerator ReportGenerator) executeTemplates(accumulatedInfoTemplateInput stucts.AccumulatedInfoTemplateInput, topQueriesTemplateInput []stucts.TopQueriesTemplateInputRecord, queryInfoTemplateInputs []stucts.QueryInfoTemplateInput) (string, error) {
 	var err error
 	var bf bytes.Buffer
 	err = reportGenerator.ReportTemplates.AccumulatedTemplate.Execute(&bf, accumulatedInfoTemplateInput)


### PR DESCRIPTION
- Use topquery object for templating instead of string
- Update templates for topquery metric